### PR TITLE
nvuApp: display user questions from in-memory datastore 

### DIFF
--- a/src/main/java/JettyMain.java
+++ b/src/main/java/JettyMain.java
@@ -1,7 +1,11 @@
+import com.clouway.nvuapp.core.InMemoryQuestionRepository;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import core.PageHandler;
 import core.PageRegistry;
+import core.Question;
 import http.controllers.HomeHandler;
+import http.controllers.QuestionListHandler;
 import http.servlet.PageHandlerServlet;
 import http.servlet.ResourceServlet;
 import http.servlet.ServerPageRegistry;
@@ -11,6 +15,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
+import java.util.List;
 
 /**
  * @author Vasil Mitov <v.mitov.clouway@gmail.com>
@@ -20,7 +25,15 @@ public class JettyMain {
 
     final PageRegistry registry = new ServerPageRegistry(
             ImmutableMap.<String, PageHandler>of(
-                    "/", new HomeHandler()
+                    "/", new HomeHandler(),
+                    "/questions", new QuestionListHandler("1234", new InMemoryQuestionRepository(
+                            ImmutableMap.<String, List<Question>>of("1234",
+                                    Lists.newArrayList(
+                                            new Question("1234", "CAT1", 23, 1, 1, 1, "How are you today?", "I feel Good", "I feel bad", "I feed unusual"),
+                                            new Question("1234", "CAT2", 23, 1, 1, 1, "How you feel today?", "I feel Good", "I feel bad", "I feed unusual")
+                                    )
+                            )
+                    ))
             ),
             new HomeHandler()
     );

--- a/src/main/java/com/clouway/nvuapp/core/InMemoryQuestionRepository.java
+++ b/src/main/java/com/clouway/nvuapp/core/InMemoryQuestionRepository.java
@@ -1,0 +1,25 @@
+package com.clouway.nvuapp.core;
+
+import core.Question;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class InMemoryQuestionRepository implements QuestionRepository {
+
+    private final Map<String, List<Question>> tutorToQuestionsListMap;
+
+    public InMemoryQuestionRepository(Map<String, List<Question>> tutorToQuestionsListMap) {
+        this.tutorToQuestionsListMap = tutorToQuestionsListMap;
+    }
+
+    @Override
+    public List<Question> getQuestions(String tutorId) {
+        if (tutorToQuestionsListMap.containsKey(tutorId)) {
+            return tutorToQuestionsListMap.get(tutorId);
+        }
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/com/clouway/nvuapp/core/QuestionRepository.java
+++ b/src/main/java/com/clouway/nvuapp/core/QuestionRepository.java
@@ -1,0 +1,11 @@
+package com.clouway.nvuapp.core;
+
+import core.Question;
+
+import java.util.List;
+
+public interface QuestionRepository {
+
+    List<Question> getQuestions(String tutorId);
+
+}

--- a/src/main/java/http/controllers/QuestionListHandler.java
+++ b/src/main/java/http/controllers/QuestionListHandler.java
@@ -1,0 +1,26 @@
+package http.controllers;
+
+import core.PageHandler;
+import com.clouway.nvuapp.core.QuestionRepository;
+import core.Request;
+import core.Response;
+import http.servlet.RsFreemarker;
+
+import java.util.Collections;
+
+public class QuestionListHandler implements PageHandler {
+    private final QuestionRepository questionRepository;
+    private final String tutorId;
+
+    public QuestionListHandler(String tutorId, QuestionRepository questionRepository) {
+        this.tutorId = tutorId;
+        this.questionRepository = questionRepository;
+    }
+
+    @Override
+    public Response handle(Request req) {
+        // TODO: pass tutorId to the handle method when user auth is implemented
+        return new RsFreemarker(
+                "questionList.html", Collections.<String, Object>singletonMap("questionList", questionRepository.getQuestions(tutorId)));
+    }
+}

--- a/src/main/java/http/servlet/PageHandlerServlet.java
+++ b/src/main/java/http/servlet/PageHandlerServlet.java
@@ -3,7 +3,6 @@ package http.servlet;
 import com.google.common.io.ByteStreams;
 import core.PageHandler;
 import core.PageRegistry;
-import core.Request;
 import core.Response;
 
 import javax.servlet.ServletException;

--- a/src/main/resources/http/servlet/home.css
+++ b/src/main/resources/http/servlet/home.css
@@ -2,6 +2,20 @@ form {
     border: 3px solid #f1f1f1;
 }
 
+.buttonlink {
+    background-color: #4CAF50;
+    color: white;
+    padding: 14px 20px;
+    margin: 8px 0;
+    border: none;
+    cursor: pointer;
+    width: 100%;
+}
+
+textarea {
+    resize: none;
+}
+
 /* Full-width inputs */
 input[type=text], input[type=password] {
     width: 100%;

--- a/src/main/resources/http/servlet/home.html
+++ b/src/main/resources/http/servlet/home.html
@@ -11,7 +11,9 @@
     <button>Създай въпрос</button>
 </div>
 <div>
-    <button>Регистрирани Въпроси</button>
+    <form action="/questionList">
+        <input class="buttonlink" type="submit" value="Регистрирани Въпроси" />
+    </form>
 </div>
 </body>
 </html>

--- a/src/main/resources/http/servlet/questionList.css
+++ b/src/main/resources/http/servlet/questionList.css
@@ -1,0 +1,12 @@
+table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+th, td {
+    padding: 8px;
+    text-align: left;
+    border-bottom: 1px solid #ddd;
+}
+
+tr:hover{background-color:#f5f5f53}

--- a/src/main/resources/http/servlet/questionList.html
+++ b/src/main/resources/http/servlet/questionList.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <link rel="stylesheet" type="text/css" href="assets/questionList.css">
+    <meta charset="UTF-8">
+    <title>View Question List</title>
+</head>
+<body>
+    <#list questionList as question>
+        <p>Вашите въпроси са:</p><br>
+                <table class="table">
+                    <tr><th>${question.question}<br>
+                    Детайли: Категория: ${question.category} , Модул: ${question.module} ,
+                    Подмодул: ${question.subModule} , Тема: ${question.theme} , Трудност: ${question.difficulty}</th></tr>
+                    <tr><td>A) ${question.answerA}</td></tr>
+                    <tr><td>B) ${question.answerB}</td></tr>
+                    <tr><td>C) ${question.answerC}</td></tr>
+                </table><br>
+        <#else>
+            <p>Няма добавени въпроси до момента</p>
+    </#list>
+</body>
+</html>

--- a/src/test/java/com/clouway/nvuapp/core/QuestionListHandlerTest.java
+++ b/src/test/java/com/clouway/nvuapp/core/QuestionListHandlerTest.java
@@ -1,0 +1,87 @@
+package com.clouway.nvuapp.core;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.io.ByteStreams;
+import core.Question;
+import core.Request;
+import core.Response;
+import http.controllers.QuestionListHandler;
+import loadquestionlisttest.FakeRequest;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Collections;
+import java.util.List;
+
+import static core.QuestionBuilder.aNewQuestion;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class QuestionListHandlerTest {
+    private final JUnitRuleMockery context = new JUnitRuleMockery();
+
+    @Test
+    public void listFewQuestion() throws Exception {
+        final Request request = new FakeRequest();
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        final InMemoryQuestionRepository questionRepository = new InMemoryQuestionRepository(
+                ImmutableMap.<String, List<Question>>of("1234", Lists.newArrayList(
+                        aNewQuestion().question("This is a question 1").answerA("True answer 1").build(),
+                        aNewQuestion().question("This is a question 2").answerA("True answer 2").build(),
+                        aNewQuestion().question("This is a question 3").answerA("True answer 3").build())
+                )
+        );
+
+        final QuestionListHandler questionListHandler = new QuestionListHandler("1234", questionRepository);
+
+        Response response = questionListHandler.handle(request);
+        ByteStreams.copy(response.body(), out);
+        String page = out.toString();
+
+        assertThat(page, containsString("This is a question 1"));
+        assertThat(page, containsString("True answer 1"));
+
+        assertThat(page, containsString("This is a question 2"));
+        assertThat(page, containsString("True answer 2"));
+
+        assertThat(page, containsString("This is a question 3"));
+        assertThat(page, containsString("True answer 3"));
+    }
+
+    @Test
+    public void noQuestionInRepository() throws Exception {
+        final Request request = context.mock(Request.class);
+        final InMemoryQuestionRepository questionRepository = new InMemoryQuestionRepository(Collections.<String, List<Question>>emptyMap());
+        final QuestionListHandler questionListHandler = new QuestionListHandler("::any tutor id::", questionRepository);
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Response response = questionListHandler.handle(request);
+        ByteStreams.copy(response.body(), out);
+        String page = out.toString();
+
+        assertThat(page, containsString("Няма добавени въпроси до момента"));
+    }
+
+    @Test
+    public void tutorHasNoQuestions() throws Exception {
+        final Request request = context.mock(Request.class);
+        final InMemoryQuestionRepository questionRepository = new InMemoryQuestionRepository(
+                Collections.<String, List<Question>>singletonMap(
+                        "89555", Lists.newArrayList(aNewQuestion().question("This is a question 1").answerA("True answer 1").build()
+                        )));
+
+        final QuestionListHandler questionListHandler = new QuestionListHandler("1234", questionRepository);
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Response response = questionListHandler.handle(request);
+        ByteStreams.copy(response.body(), out);
+        String page = out.toString();
+
+        assertThat(page, containsString("Няма добавени въпроси до момента"));
+    }
+
+
+}

--- a/src/test/java/core/QuestionBuilder.java
+++ b/src/test/java/core/QuestionBuilder.java
@@ -4,6 +4,13 @@ package core;
  * @author Vasil Mitov <v.mitov.clouway@gmail.com>
  */
 public class QuestionBuilder {
+
+
+  public static QuestionBuilder aNewQuestion() {
+    return new QuestionBuilder();
+  }
+
+
   private String tutorId = "IF000";
   private String category = "A0";
   private Integer mod = 0;

--- a/src/test/java/loadquestionlisttest/FakeRequest.java
+++ b/src/test/java/loadquestionlisttest/FakeRequest.java
@@ -1,0 +1,17 @@
+package loadquestionlisttest;
+
+import core.Request;
+
+import javax.servlet.http.Cookie;
+
+public class FakeRequest implements Request {
+    @Override
+    public String param(String name) {
+        return null;
+    }
+
+    @Override
+    public Cookie cookie(String cookieName) {
+        return null;
+    }
+}


### PR DESCRIPTION
All questions entered by the user are now displayed in separate page. The information for the questions is currently in the code in an in-memory implementation. In following PR will be added persistent implementation that uses MySql.

Here is a sample how questions are rendered on the screen: 
![screenshot from 2017-01-09 12-27-54](https://cloud.githubusercontent.com/assets/20161493/21763554/1acba7a6-d667-11e6-9498-7f2ccf77cae8.png)


Related with #14 